### PR TITLE
Added a way to customize image_optim options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ compress_images:
 
 if you don't configure your default path will be `assets/img/**/*.{gif,png,jpg,jpeg,svg}`
 
+## image_optim options
+
+You can pass [image_optim](https://github.com/toy/image_optim) options by using
+
+```ruby
+imageoptim:
+  pngout: false
+  svgo: true
+  verbose: false
+```
+
 # Usage
 
 on  `jekyll serve` or in `jekyll build` you will run compression, if your images are already compressed, you don't need to worry because it will not run again which will save bunch of time! :)

--- a/lib/jekyll-compress-images.rb
+++ b/lib/jekyll-compress-images.rb
@@ -9,12 +9,14 @@ module Jekyll
     def generate(site)
 
       config = YAML::load_file "_config.yml"
-
       config = config["compress_images"] || {}
-
       @config = default_options.merge! config
 
-      @image_optim = ImageOptim.new pngout: false, svgo: true, verbose: false
+      imageoptim_options = YAML::load_file "_config.yml"
+      imageoptim_options = imageoptim_options["imageoptim"] || {}
+      @imageoptim_options = default_imageoptim_options.merge! imageoptim_options
+
+      @image_optim = ImageOptim.new @imageoptim_options
 
       @last_update = YAML::load_file @config["cache_file"] if File.file? @config["cache_file"]
       @last_update ||= {}
@@ -27,7 +29,15 @@ module Jekyll
     def default_options
       {
         "cache_file" => "_compress_images_cache.yml",
-        "images_path" => "assets/img/**/*.{gif,png,jpg,jpeg,svg}",
+        "images_path" => "assets/img/**/*.{gif,png,jpg,jpeg,svg}"
+      }
+    end
+
+    def default_imageoptim_options
+      {
+        "pngout" => false, 
+        "svgo" => true, 
+        "verbose" => false
       }
     end
 


### PR DESCRIPTION
## What?

Added a way to customize image_optin options in the _config.yml

## Why?

Per default the `svgo` option is set to true. Since I haven't got `svgo` installed and wanted to get rid of the warning I added the option.